### PR TITLE
Remove sudo prefixes (not needed any more in YunoHost 2.6)

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
         "url": "http://example.com"
     },
     "requirements": {
-        "yunohost": ">> 2.6.4"
+        "yunohost": ">= 2.6.4"
     },
     "multi_instance": true,
     "services": [

--- a/manifest.json
+++ b/manifest.json
@@ -14,7 +14,7 @@
         "url": "http://example.com"
     },
     "requirements": {
-        "yunohost": ">> 2.5.6"
+        "yunohost": ">> 2.6.4"
     },
     "multi_instance": true,
     "services": [

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -10,7 +10,7 @@
 ynh_add_nginx_config () {
 	finalnginxconf="/etc/nginx/conf.d/$domain.d/$app.conf"
 	ynh_backup_if_checksum_is_different "$finalnginxconf" 1
-	sudo cp ../conf/nginx.conf "$finalnginxconf"
+	cp ../conf/nginx.conf "$finalnginxconf"
 
 	# To avoid a break by set -u, use a void substitution ${var:-}. If the variable is not set, it's simply set with an empty variable.
 	# Substitute in a nginx config file only if the variable is not empty
@@ -31,7 +31,7 @@ ynh_add_nginx_config () {
 	fi
 	ynh_store_checksum_config "$finalnginxconf"
 
-	sudo systemctl reload nginx
+	systemctl reload nginx
 }
 
 # Remove the dedicated nginx config
@@ -39,7 +39,7 @@ ynh_add_nginx_config () {
 # usage: ynh_remove_nginx_config
 ynh_remove_nginx_config () {
 	ynh_secure_remove "/etc/nginx/conf.d/$domain.d/$app.conf"
-	sudo systemctl reload nginx
+	systemctl reload nginx
 }
 
 # Create a dedicated php-fpm config
@@ -48,23 +48,23 @@ ynh_remove_nginx_config () {
 ynh_add_fpm_config () {
 	finalphpconf="/etc/php5/fpm/pool.d/$app.conf"
 	ynh_backup_if_checksum_is_different "$finalphpconf" 1
-	sudo cp ../conf/php-fpm.conf "$finalphpconf"
+	cp ../conf/php-fpm.conf "$finalphpconf"
 	ynh_replace_string "__NAMETOCHANGE__" "$app" "$finalphpconf"
 	ynh_replace_string "__FINALPATH__" "$final_path" "$finalphpconf"
 	ynh_replace_string "__USER__" "$app" "$finalphpconf"
-	sudo chown root: "$finalphpconf"
+	chown root: "$finalphpconf"
 	ynh_store_file_checksum "$finalphpconf"
 
 	if [ -e "../conf/php-fpm.ini" ]
 	then
 		finalphpini="/etc/php5/fpm/conf.d/20-$app.ini"
 		ynh_compare_checksum_config "$finalphpini" 1
-		sudo cp ../conf/php-fpm.ini "$finalphpini"
-		sudo chown root: "$finalphpini"
+		cp ../conf/php-fpm.ini "$finalphpini"
+		chown root: "$finalphpini"
 		ynh_store_checksum_config "$finalphpini"
 	fi
 
-	sudo systemctl reload php5-fpm
+	systemctl reload php5-fpm
 }
 
 # Remove the dedicated php-fpm config
@@ -73,7 +73,7 @@ ynh_add_fpm_config () {
 ynh_remove_fpm_config () {
 	ynh_secure_remove "/etc/php5/fpm/pool.d/$app.conf"
 	ynh_secure_remove "/etc/php5/fpm/conf.d/20-$app.ini" 2>&1
-	sudo systemctl reload php5-fpm
+	systemctl reload php5-fpm
 }
 
 # Create a dedicated systemd config
@@ -82,7 +82,7 @@ ynh_remove_fpm_config () {
 ynh_add_systemd_config () {
 	finalsystemdconf="/etc/systemd/system/$app.service"
 	ynh_compare_checksum_config "$finalsystemdconf" 1
-	sudo cp ../conf/systemd.service "$finalsystemdconf"
+	cp ../conf/systemd.service "$finalsystemdconf"
 
 	# To avoid a break by set -u, use a void substitution ${var:-}. If the variable is not set, it's simply set with an empty variable.
 	# Substitute in a nginx config file only if the variable is not empty
@@ -94,9 +94,9 @@ ynh_add_systemd_config () {
 	fi
 	ynh_store_checksum_config "$finalsystemdconf"
 
-	sudo chown root: "$finalsystemdconf"
-	sudo systemctl enable $app
-	sudo systemctl daemon-reload
+	chown root: "$finalsystemdconf"
+	systemctl enable $app
+	systemctl daemon-reload
 }
 
 # Remove the dedicated systemd config
@@ -105,8 +105,8 @@ ynh_add_systemd_config () {
 ynh_remove_systemd_config () {
 	finalsystemdconf="/etc/systemd/system/$app.service"
 	if [ -e "$finalsystemdconf" ]; then
-		sudo systemctl stop $app
-		sudo systemctl disable $app
+		systemctl stop $app
+		systemctl disable $app
 		ynh_secure_remove "$finalsystemdconf"
 	fi
 }

--- a/scripts/backup
+++ b/scripts/backup
@@ -15,8 +15,8 @@ set -eu
 
 if [ ! -e _common.sh ]; then
 	# Get the _common.sh file if it's not in the current directory
-	sudo cp ../settings/scripts/_common.sh ./_common.sh
-	sudo chmod a+rx _common.sh
+	cp ../settings/scripts/_common.sh ./_common.sh
+	chmod a+rx _common.sh
 fi
 source _common.sh
 source /usr/share/yunohost/helpers

--- a/scripts/install
+++ b/scripts/install
@@ -72,7 +72,7 @@ ynh_app_setting_set $app language $language
 # Find a free port
 port=$(ynh_find_port 8095)
 # Open this port
-sudo yunohost firewall allow --no-upnp TCP $port 2>&1
+yunohost firewall allow --no-upnp TCP $port 2>&1
 ynh_app_setting_set $app port $port
 
 #=================================================
@@ -138,15 +138,15 @@ ynh_systemd_config
 #=================================================
 
 # Set right permissions for curl install
-sudo chown -R $app: $final_path
+chown -R $app: $final_path
 
 # Set the app as temporarily public for curl call
 ynh_app_setting_set $app unprotected_uris "/"
 # Reload SSOwat config
-sudo yunohost app ssowatconf
+yunohost app ssowatconf
 
 # Reload Nginx
-sudo systemctl reload nginx
+systemctl reload nginx
 
 # Installation with curl
 ynh_local_curl "/INSTALL_PATH" "key1=value1" "key2=value2" "key3=value3"
@@ -165,7 +165,7 @@ ynh_store_file_checksum "$final_path/CONFIG_FILE"
 #=================================================
 
 # Set permissions to app files
-sudo chown -R root: $final_path
+chown -R root: $final_path
 
 #=================================================
 # SETUP LOGROTATE
@@ -178,7 +178,7 @@ ynh_use_logrotate
 # ADVERTISE SERVICE IN ADMIN PANEL
 #=================================================
 
-sudo yunohost service add NAME_INIT.D --log "/var/log/FILE.log"
+yunohost service add NAME_INIT.D --log "/var/log/FILE.log"
 
 #=================================================
 # SETUP SSOWAT
@@ -199,4 +199,4 @@ fi
 # RELOAD NGINX
 #=================================================
 
-sudo systemctl reload nginx
+systemctl reload nginx

--- a/scripts/remove
+++ b/scripts/remove
@@ -32,10 +32,10 @@ ynh_remove_systemd_config
 # REMOVE SERVICE FROM ADMIN PANEL
 #=================================================
 
-if sudo yunohost service status | grep -q $app
+if yunohost service status | grep -q $app
 then
 	echo "Remove $app service"
-	sudo yunohost service remove $app
+	yunohost service remove $app
 fi
 
 #=================================================
@@ -84,10 +84,10 @@ ynh_remove_logrotate
 # CLOSE A PORT
 #=================================================
 
-if sudo yunohost firewall list | grep -q "\- $port$"
+if yunohost firewall list | grep -q "\- $port$"
 then
 	echo "Close port $port"
-	QUIET sudo yunohost firewall disallow TCP $port
+	QUIET yunohost firewall disallow TCP $port
 fi
 
 #=================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -15,8 +15,8 @@ set -eu
 
 if [ ! -e _common.sh ]; then
 	# Get the _common.sh file if it's not in the current directory
-	sudo cp ../settings/scripts/_common.sh ./_common.sh
-	sudo chmod a+rx _common.sh
+	cp ../settings/scripts/_common.sh ./_common.sh
+	chmod a+rx _common.sh
 fi
 source _common.sh
 source /usr/share/yunohost/helpers
@@ -36,7 +36,7 @@ db_name=$(ynh_app_setting_get $app db_name)
 # CHECK IF THE APP CAN BE RESTORED
 #=================================================
 
-sudo yunohost app checkurl "${domain}${path_url}" -a "$app" \
+yunohost app checkurl "${domain}${path_url}" -a "$app" \
 	|| ynh_die "Path not available: ${domain}${path_url}"
 test ! -d $final_path \
 	|| ynh_die "There is already a directory: $final_path "
@@ -75,7 +75,7 @@ ynh_system_user_create $app
 #=================================================
 
 # Restore permissions on app files
-sudo chown -R root: $final_path
+chown -R root: $final_path
 
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION
@@ -97,14 +97,14 @@ ynh_install_app_dependencies deb1 deb2
 # ADVERTISE SERVICE IN ADMIN PANEL
 #=================================================
 
-sudo yunohost service add $app --log "/var/log/$app/APP.log"
+yunohost service add $app --log "/var/log/$app/APP.log"
 
 #=================================================
 # RESTORE SYSTEMD
 #=================================================
 
 ynh_restore_file "/etc/systemd/system/$app.service"
-sudo systemctl enable $app.service
+systemctl enable $app.service
 
 #=================================================
 # RESTORE THE CRON FILE
@@ -124,5 +124,5 @@ ynh_restore_file "/etc/logrotate.d/$app"
 # RELOAD NGINX AND PHP-FPM
 #=================================================
 
-sudo systemctl reload php5-fpm
-sudo systemctl reload nginx
+systemctl reload php5-fpm
+systemctl reload nginx

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -109,7 +109,7 @@ ynh_systemd_config
 #=================================================
 
 # Set right permissions for curl installation
-sudo chown -R root: $final_path
+chown -R root: $final_path
 
 #=================================================
 # SETUP SSOWAT
@@ -130,4 +130,4 @@ fi
 # RELOAD NGINX
 #=================================================
 
-sudo systemctl reload nginx
+systemctl reload nginx


### PR DESCRIPTION
## Problem
Sudo is no more necessary. If we forgot one it could be ok in 2.6.4 but not in 2.5.

## Solution
We encourage to put a requirements to yunohost 2.6.4 and remove sudo from this example app.

## PR Status
Work finished. Could be reviewed and tested.

## Validation

- [x] **Principle agreement** 2/2 : ljf, Maniack C
- [x] **Quick review** 1/1 : ljf
- [ ] **Simple test** 0/1 : 
- [x] **Deep review** 1/1: Maniack C
- [ ] **Complex test** 0/0