### PR TITLE
Rename to check_process.default

### DIFF
--- a/check_process.default
+++ b/check_process.default
@@ -1,5 +1,8 @@
 # See here for more informations
 # https://github.com/YunoHost/package_check#syntax-check_process-file
+
+# Move this file from check_process.default to check_process when you have filled it.
+
 ;; Test complet
 	; Manifest
 		domain="domain.tld"	(DOMAIN)


### PR DESCRIPTION
Like that, package_check will not use this file until it is really filled.

## Problem
- *package_check uses this default check_process, even if it is still the default one.*  
*We can have some useless errors with this file.*

## Solution
- *Move the file to check_process.default to prevent package_check from using it.*

## Validation
*Minor decision*
- ~**Upgrade previous version** :~
- [x] **Code review** : JimboJoe
- [x] **Approval (LGTM)** : JimboJoe
- [x] **Approval (LGTM)** : frju365
- ~**CI succeeded** :~
When the PR is marked as ready to merge, you have to wait for 3 days before really merging it.