### PR TITLE
[enh] Update install and documentation

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -276,7 +276,9 @@ ynh_use_logrotate
 ###		- Remove the section "REMOVE SERVICE FROM ADMIN PANEL" in the remove script
 ###		- As well as the section ADVERTISE SERVICE IN ADMIN PANEL" in the restore script
 
-yunohost service add NAME_INIT.D --log "/var/log/FILE.log"
+yunohost service add $app --log "/var/log/$app/APP.log"
+# if using yunohost version 3.2 or more in the 'manifest.json', a description can be added
+#yunohost service add $app --description "$app daemon for XXX" --log "/var/log/$app/APP.log"
 
 #=================================================
 # SETUP SSOWAT


### PR DESCRIPTION
Proposal of two changes:

1. Change "service management" to be consistent with 'restore' script. See https://github.com/YunoHost/example_ynh/blob/master/scripts/restore#L99
2. Add a comment about the possibility of adding a description since Yunohost 3.2 (optional and can be removed as it is cherry on top of the cake feature and could be confusing)