### PR TITLE
Improve detection that service exists for yunohost

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -29,7 +29,7 @@ final_path=$(ynh_app_setting_get $app final_path)
 #=================================================
 
 # Remove a service from the admin panel, added by `yunohost service add`
-if yunohost service status | grep -q $app
+if yunohost service status $app >/dev/null 2>&1
 then
 	ynh_print_info "Removing $app service"
 	yunohost service remove $app


### PR DESCRIPTION
`yunohost service status` will actually trigger a `systemctl status` for every status it knows ... but we just want to know if one service exists. So this small change should be more efficient.