### PR TITLE
comment the usage of _common.sh

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -6,6 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
+#Keep this path for calling _common.sh inside the execution's context of backup and restore scripts
 source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 

--- a/scripts/restore
+++ b/scripts/restore
@@ -6,6 +6,7 @@
 # IMPORT GENERIC HELPERS
 #=================================================
 
+#Keep this path for calling _common.sh inside the execution's context of backup and restore scripts
 source ../settings/scripts/_common.sh
 source /usr/share/yunohost/helpers
 


### PR DESCRIPTION
For noobs, like me.
I doesn't found on documentation why the source is different on my "normal" scripts (install, remove, upgrade) and my "save" files (backup and restore). This comment add this small, but precious information.