### PR TITLE
Normalizing url ain't needed anymore

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -34,15 +34,6 @@ final_path=$(ynh_app_setting_get $app final_path)
 #db_pwd=$(ynh_app_setting_get $app db_pwd)
 
 #=================================================
-# CHECK THE SYNTAX OF THE PATHS
-#=================================================
-
-test -n "$old_path" || old_path="/"
-test -n "$new_path" || new_path="/"
-new_path=$(ynh_normalize_url_path $new_path)
-old_path=$(ynh_normalize_url_path $old_path)
-
-#=================================================
 # CHECK WHICH PARTS SHOULD BE CHANGED
 #=================================================
 

--- a/scripts/install
+++ b/scripts/install
@@ -53,9 +53,6 @@ ynh_print_info "Validating installation parameters..."
 final_path=/var/www/$app
 test ! -e "$final_path" || ynh_die "This path already contains a folder"
 
-# Normalize the url path syntax
-path_url=$(ynh_normalize_url_path $path_url)
-
 # Register (book) web path
 ynh_webpath_register $app $domain $path_url
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -65,6 +65,18 @@ ynh_clean_setup () {
 ynh_abort_if_errors
 
 #=================================================
+# CHECK THE PATH
+#=================================================
+
+# Normalize the URL path syntax
+# N.B. : this is for app installations before YunoHost 2.7
+# where this value might be something like /foo/ or foo/
+# instead of /foo ....
+# If nobody installed your app before 2.7, then you may
+# safely remove this line
+path_url=$(ynh_normalize_url_path $path_url)
+
+#=================================================
 # STANDARD UPGRADE STEPS
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -65,13 +65,6 @@ ynh_clean_setup () {
 ynh_abort_if_errors
 
 #=================================================
-# CHECK THE PATH
-#=================================================
-
-# Normalize the URL path syntax
-path_url=$(ynh_normalize_url_path $path_url)
-
-#=================================================
 # STANDARD UPGRADE STEPS
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE


### PR DESCRIPTION
It's been a while since you actually don't need to normalize the path anymore ... it's done automatically by YunoHost (and also for the change_url case)

https://github.com/YunoHost/yunohost/blob/stretch-testing/src/yunohost/app.py#L2286

You can check it by launching an app script and feeding values like `////trololo////` or `foo/` or `/////` and printing the value of `$path_url` before running the helper...