### PR TITLE
[enh] Apply backup core only policy

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -33,6 +33,16 @@ domain=$(ynh_app_setting_get $app domain)
 db_name=$(ynh_app_setting_get $app db_name)
 
 #=================================================
+# APPLY BACKUP CORE ONLY POLICY
+#=================================================
+# Apply policy only if we are not in upgrade mode
+BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-auto}
+if [ "$BACKUP_CORE_ONLY" == "auto" ] ; then
+    BACKUP_CORE_ONLY=$(ynh_app_setting_get $app backup_core_only)
+    BACKUP_CORE_ONLY=${BACKUP_CORE_ONLY:-0}
+fi
+
+#=================================================
 # STANDARD BACKUP STEPS
 #=================================================
 # BACKUP THE APP MAIN DIR


### PR DESCRIPTION
I suggest to add this in backup script  with "big" backup dir. It allows user to indicate if they want backup this data or not.

Alternatively, we could add this in python core