### PR TITLE
Php fpm

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -52,6 +52,14 @@ ynh_script_progression --message="Removing the MySQL database..." --time --weigh
 ynh_mysql_remove_db --db_user=$db_user --db_name=$db_name
 
 #=================================================
+# REMOVE PHP-FPM CONFIGURATION
+#=================================================
+ynh_script_progression --message="Removing php-fpm configuration..." --time --weight=1
+
+# Remove the dedicated php-fpm config
+ynh_remove_fpm_config
+
+#=================================================
 # REMOVE DEPENDENCIES
 #=================================================
 ynh_script_progression --message="Removing dependencies..." --time --weight=1
@@ -74,14 +82,6 @@ ynh_script_progression --message="Removing nginx web server configuration..." --
 
 # Remove the dedicated nginx config
 ynh_remove_nginx_config
-
-#=================================================
-# REMOVE PHP-FPM CONFIGURATION
-#=================================================
-ynh_script_progression --message="Removing php-fpm configuration..." --time --weight=1
-
-# Remove the dedicated php-fpm config
-ynh_remove_fpm_config
 
 #=================================================
 # REMOVE LOGROTATE CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -75,12 +75,6 @@ ynh_system_user_create --username=$app
 chown -R root: $final_path
 
 #=================================================
-# RESTORE THE PHP-FPM CONFIGURATION
-#=================================================
-
-ynh_restore_file --origin_path="/etc/php/7.0/fpm/pool.d/$app.conf"
-
-#=================================================
 # RESTORE FAIL2BAN CONFIGURATION
 #=================================================
 ynh_script_progression --message="Restoring the fail2ban configuration..." --time --weight=1
@@ -107,6 +101,12 @@ ynh_script_progression --message="Restoring the MySQL database..." --time --weig
 db_pwd=$(ynh_app_setting_get --app=$app --key=mysqlpwd)
 ynh_mysql_setup_db --db_user=$db_user --db_name=$db_name --db_pwd=$db_pwd
 ynh_mysql_connect_as --user=$db_user --password=$db_pwd --database=$db_name < ./db.sql
+
+#=================================================
+# RESTORE THE PHP-FPM CONFIGURATION
+#=================================================
+
+ynh_restore_file --origin_path="/etc/php/7.0/fpm/pool.d/$app.conf"
 
 #=================================================
 # RESTORE SYSTEMD


### PR DESCRIPTION
I propose to change the php-fpm step order.

I'm considering package using php7.1, 7.2, etc...  and installing php7.1, 7.2, etc... during the `INSTALL DEPENDENCIES` step

- during removal it's better to have php-fpm removal before dependencies removal
- during restore we must first install dependencies and then restore php-fpm