### PR TITLE
Backup before changing url.

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -35,6 +35,23 @@ final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 #db_pwd=$(ynh_app_setting_get --app=$app --key=db_pwd)
 
 #=================================================
+# BACKUP BEFORE UPGRADE THEN ACTIVE TRAP
+#=================================================
+ynh_script_progression --message="Backing up the app before changing its url (may take a while)..." --time --weight=1
+
+# Backup the current version of the app
+ynh_backup_before_upgrade
+ynh_clean_setup () {
+	# Remove the new domain config file, the remove script won't do it as it doesn't know yet its location.
+	ynh_secure_remove --file="/etc/nginx/conf.d/$new_domain.d/$app.conf"
+
+	# restore it if the upgrade fails
+	ynh_restore_upgradebackup
+}
+# Exit if an error occurs during the execution of the script
+ynh_abort_if_errors
+
+#=================================================
 # CHECK WHICH PARTS SHOULD BE CHANGED
 #=================================================
 


### PR DESCRIPTION
## Problem
- *If a changeurl script fails, the app will end in a none fully moved state. Forcing the user to fix it by himself.*

## Solution
- *Use `ynh_backup_before_upgrade` into the changeurl script.*
- *Remove the nginx config file for the new domain, the remove script will try to remove the old one, as the modification of the config would have happened at the end.*

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x] Can be reviewed and tested.