### PR TITLE
For god sake please stop writing "$app for YunoHost" in the description

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
     "id": "ynhexample",
     "packaging_format": 1,
     "description": {
-        "en": "Example package for YunoHost application.",
-        "fr": "Exemple de package d’application pour YunoHost."
+        "en": "Explain in *a few (10~15) words* what your app actually is or does (for god sake please don't just say it's '$app for Yunohost'! It is meant to be displayed in the app catalog to users who want a rough idea of what it is or does among 100+ others.)",
+        "fr": "Expliquez en *quelques* (10~15) mots ce que l'app est ou fait (par pitié ne dite pas juste '$app pour Yunohost'! Elle sera affichée sur le catalog d'app aux users qui veulent à savoir ce que fait l'app parmis une centaine d'autre...)"
     },
     "version": "1.0~ynh1",
     "url": "https://example.com",

--- a/manifest.json
+++ b/manifest.json
@@ -3,8 +3,8 @@
     "id": "ynhexample",
     "packaging_format": 1,
     "description": {
-        "en": "Explain in *a few (10~15) words* what your app actually is or does (for god sake please don't just say it's '$app for Yunohost'! It is meant to be displayed in the app catalog to users who want a rough idea of what it is or does among 100+ others.)",
-        "fr": "Expliquez en *quelques* (10~15) mots ce que l'app est ou fait (par pitié ne dite pas juste '$app pour Yunohost'! Elle sera affichée sur le catalog d'app aux users qui veulent à savoir ce que fait l'app parmis une centaine d'autre...)"
+        "en": "Explain in *a few (10~15) words* the purpose of the app or what it actually does (it is meant to give a rough idea to users browsing a catalog of 100+ apps)",
+        "fr": "Expliquez en *quelques* (10~15) mots l'utilité de l'app ou ce qu'elle fait (l'objectif est de donner une idée grossière pour des utilisateurs qui naviguent dans un catalogue de 100+ apps)"
     },
     "version": "1.0~ynh1",
     "url": "https://example.com",


### PR DESCRIPTION
## Problem
- People constantly writing $app for Yunohost (or similar stuff) which is pointless because ... yes, this is a Yunohost app ! The point is that these descriptions are meant (among other things) to be displayed in the app catalog where people browse 100+ apps and want a rough idea of what it actually does ...

## Solution

- Since my guess is that example_ynh is used as a template, avoid writing "Template app for Yunohost" where packagers are likely to just replace with "$their_app for Yunohost" .... 
