### PR TITLE
Tweak explanation about "yunohost service add" + add tips for 3.8

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -283,20 +283,26 @@ ynh_script_progression --message="Configuring log rotation..." --time --weight=1
 ynh_use_logrotate
 
 #=================================================
-# ADVERTISE SERVICE IN ADMIN PANEL
+# INTEGRATE SERVICE IN YUNOHOST
 #=================================================
 
-### `yunohost service add` is a CLI yunohost command to add a service in the admin panel.
-### You'll find the service in the 'services' section of YunoHost admin panel.
-### This CLI command would be useless if the app does not have any services (systemd or sysvinit)
+### `yunohost service add` integrates a service in YunoHost. It then gets 
+### displayed in the admin interface and through the others `yunohost service` commands.
+### (N.B. : this line only makes sense if the app adds a service to the system!)
 ### If you're not using these lines:
 ###		- You can remove these files in conf/.
 ###		- Remove the section "REMOVE SERVICE FROM ADMIN PANEL" in the remove script
 ###		- As well as the section "ADVERTISE SERVICE IN ADMIN PANEL" in the restore script
 
-yunohost service add $app --log "/var/log/$app/$app.log"
-# if using yunohost version 3.2 or more in the 'manifest.json', a description can be added
-#yunohost service add $app --description "$app daemon for XXX" --log "/var/log/$app/$app.log"
+yunohost service add $app --description "A short description of the app" --log "/var/log/$app/$app.log"
+
+### With YunoHost 3.8 you will then be able to: 
+### - specify a list of ports that needs to be publicly exposed (c.f. --needs_exposed_ports) 
+###   which will then be checked by YunoHost's diagnosis system
+### - specify a custom command to check the status of the service (c.f. --test_status)
+###   though it's only needed for weird cases where 'systemctl status' doesn't do a good job
+### - specify a custom command to check / validate the configuration of the service (c.f. --test_conf)
+###   for example, the command to check the configuration of nginx is "nginx -t"
 
 #=================================================
 # START SYSTEMD SERVICE

--- a/scripts/remove
+++ b/scripts/remove
@@ -25,10 +25,10 @@ final_path=$(ynh_app_setting_get --app=$app --key=final_path)
 #=================================================
 # STANDARD REMOVE
 #=================================================
-# REMOVE SERVICE FROM ADMIN PANEL
+# REMOVE SERVICE INTEGRATION IN YUNOHOST
 #=================================================
 
-# Remove a service from the admin panel, added by `yunohost service add`
+# Remove the service from the list of services known by Yunohost (added from `yunohost service add`)
 if ynh_exec_warn_less yunohost service status $app >/dev/null
 then
 	ynh_script_progression --message="Removing $app service..." --time --weight=1

--- a/scripts/restore
+++ b/scripts/restore
@@ -117,10 +117,10 @@ ynh_restore_file --origin_path="/etc/systemd/system/$app.service"
 systemctl enable $app.service
 
 #=================================================
-# ADVERTISE SERVICE IN ADMIN PANEL
+# INTEGRATE SERVICE IN YUNOHOST
 #=================================================
 
-yunohost service add $app --log "/var/log/$app/$app.log"
+yunohost service add $app --description "A short description of the app" --log "/var/log/$app/$app.log"
 
 #=================================================
 # START SYSTEMD SERVICE


### PR DESCRIPTION
(N.B. : it's not just about integrating the service in the webadmin. It's also available in `yunohost service list` and there are features / changes coming in 3.8 that will allow to make much more sense of this)