### PR TITLE
example_ynh readme reworked

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Usage of this package (REMOVE THIS SECTION BEFORE RELEASE)
 - Copy this app before working on it.
-- Edit `conf/nginx.conf` file to match application prerequisites.
-- Edit `manifest.json` with application specific information.
+- Edit the `conf/nginx.conf` file to match app prerequisites.
+- Edit the `manifest.json` with app specific info.
 - Edit the `install`, `upgrade`, `remove`, `backup`, and `restore` scripts.
   - Using the [script helpers documentation.](https://helpers.yunohost.org/)
 - Add a `LICENSE` file for the package.
-- Edit `README.md` and README_fr.md.
+- Edit `README.md` and `README_fr.md`.
 
 # Example app for YunoHost
 
@@ -14,8 +14,8 @@
 
 *[Lire ce readme en français.](./README_fr.md)*
 
-> *This package allow you to install REPLACEBYYOURAPP quickly and simply on a YunoHost server.  
-If you don't have YunoHost, please see [here](https://yunohost.org/#/install) to know how to install and enjoy it.*
+> *This package allows you to install REPLACEBYYOURAPP quickly and simply on a YunoHost server.  
+If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/install) to learn how to install it.*
 
 ## Overview
 Quick description of this app.
@@ -24,15 +24,15 @@ Quick description of this app.
 
 ## Screenshots
 
-![](Link to an screenshot for this app)
+![](Link to a screenshot of this app.)
 
 ## Demo
 
-* [Official demo](Link to a demo site for this app)
+* [Official demo](Link to a demo site for this app.)
 
 ## Configuration
 
-How to configure this app: by an admin panel, a plain file with SSH, or any other way.
+How to configure this app: From an admin panel, a plain file with SSH, or any other way.
 
 ## Documentation
 
@@ -41,14 +41,14 @@ How to configure this app: by an admin panel, a plain file with SSH, or any othe
 
 ## YunoHost specific features
 
-#### Multi-users support
+#### Multi-user support
 
 Are LDAP and HTTP auth supported?
 Can the app be used by multiple users?
 
 #### Supported architectures
 
-* x86-64b - [![Build Status](https://ci-apps.yunohost.org/ci/logs/REPLACEBYYOURAPP%20%28Apps%29.svg)](https://ci-apps.yunohost.org/ci/apps/REPLACEBYYOURAPP/)
+* x86-64 - [![Build Status](https://ci-apps.yunohost.org/ci/logs/REPLACEBYYOURAPP%20%28Apps%29.svg)](https://ci-apps.yunohost.org/ci/apps/REPLACEBYYOURAPP/)
 * ARMv8-A - [![Build Status](https://ci-apps-arm.yunohost.org/ci/logs/REPLACEBYYOURAPP%20%28Apps%29.svg)](https://ci-apps-arm.yunohost.org/ci/apps/REPLACEBYYOURAPP/)
 
 ## Limitations
@@ -57,25 +57,25 @@ Can the app be used by multiple users?
 
 ## Additional information
 
-* Other information you would add about this application
+* Other info you would like to add about this app.
 
-**More information on the documentation page:**  
+**More info on the documentation page:**  
 https://yunohost.org/packaging_apps
 
 ## Links
 
  * Report a bug: https://github.com/YunoHost-Apps/REPLACEBYYOURAPP_ynh/issues
- * App website: Link to the official website of this app
- * Upstream app repository: Link to the official repository of the upstream app
+ * App website: Link to the official website of this app.
+ * Upstream app repository: Link to the official repository of the upstream app.
  * YunoHost website: https://yunohost.org/
 
 ---
 
-Developers info
+Developer info
 ----------------
 
 **Only if you want to use a testing branch for coding, instead of merging directly into master.**
-Please do your pull request to the [testing branch](https://github.com/YunoHost-Apps/REPLACEBYYOURAPP_ynh/tree/testing).
+Please send your pull request to the [testing branch](https://github.com/YunoHost-Apps/REPLACEBYYOURAPP_ynh/tree/testing).
 
 To try the testing branch, please proceed like that.
 ```


### PR DESCRIPTION
Further edits would have to be replicated in the French version.
I think maybe stating that markdown links are to be used is useful. Also they should IMO have alt tags.
There is an exclamation mark that I don't know what does [here](https://github.com/YunoHost-Apps/wikijs_ynh/pull/85/files#diff-04c6e90faac2675aa89e2176d2eec7d8R44).
https://daringfireball.net/projects/markdown/syntax.text details how to do it.

## Problem
Initial info

## Solution
Fixed

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [x ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/REPLACEBYYOURAPP_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/REPLACEBYYOURAPP_ynh%20PR-NUM-%20(USERNAME)/)  
