### PR TITLE
Clarify some things about backup script

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -24,7 +24,7 @@ ynh_abort_if_errors
 #=================================================
 # LOAD SETTINGS
 #=================================================
-ynh_script_progression --message="Loading installation settings..." --time --weight=1
+ynh_print_info --message="Loading installation settings..."
 
 app=$YNH_APP_INSTANCE_NAME
 
@@ -33,41 +33,37 @@ domain=$(ynh_app_setting_get --app=$app --key=domain)
 db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 
 #=================================================
-# STANDARD BACKUP STEPS
+# DECLARE DATA AND CONF FILES TO BACKUP
 #=================================================
+
+ynh_print_info --message="Declaring files to be backuped..."
+
+# N.B. : the following 'ynh_backup' calls are only a *declaration* of what needs
+# to be backuped and not an actual copy of any file. The actual backup that
+# creates and fill the archive with the files happens in the core after this
+# script is called. Hence ynh_backups calls takes basically 0 seconds to run.
 
 #=================================================
 # BACKUP THE APP MAIN DIR
 #=================================================
-ynh_script_progression --message="Backing up the main app directory..." --time --weight=1
 
 ynh_backup --src_path="$final_path"
 
 #=================================================
 # BACKUP THE NGINX CONFIGURATION
 #=================================================
-ynh_script_progression --message="Backing up nginx web server configuration..." --time --weight=1
 
 ynh_backup --src_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 
 #=================================================
 # BACKUP THE PHP-FPM CONFIGURATION
 #=================================================
-ynh_script_progression --message="Backing up php-fpm configuration..." --time --weight=1
 
 ynh_backup --src_path="/etc/php/7.0/fpm/pool.d/$app.conf"
 
 #=================================================
-# BACKUP THE MYSQL DATABASE
-#=================================================
-ynh_script_progression --message="Backing up the MySQL database..." --time --weight=1
-
-ynh_mysql_dump_db --database="$db_name" > db.sql
-
-#=================================================
 # BACKUP FAIL2BAN CONFIGURATION
 #=================================================
-ynh_script_progression --message="Backing up fail2ban configuration..." --time --weight=1
 
 ynh_backup --src_path="/etc/fail2ban/jail.d/$app.conf"
 ynh_backup --src_path="/etc/fail2ban/filter.d/$app.conf"
@@ -77,14 +73,12 @@ ynh_backup --src_path="/etc/fail2ban/filter.d/$app.conf"
 #=================================================
 # BACKUP LOGROTATE
 #=================================================
-ynh_script_progression --message="Backing up logrotate configuration..." --time --weight=1
 
 ynh_backup --src_path="/etc/logrotate.d/$app"
 
 #=================================================
 # BACKUP SYSTEMD
 #=================================================
-ynh_script_progression --message="Backing up systemd configuration..." --time --weight=1
 
 ynh_backup --src_path="/etc/systemd/system/$app.service"
 
@@ -95,7 +89,18 @@ ynh_backup --src_path="/etc/systemd/system/$app.service"
 ynh_backup --src_path="/etc/cron.d/$app"
 
 #=================================================
+# BACKUP THE MYSQL DATABASE
+#=================================================
+
+ynh_print_info --message="Backing up the database..."
+
+# (However, things like mysql dumps *do* take some time to run, though the
+# copy of the generated dump to the archive still happens later)
+
+ynh_mysql_dump_db --database="$db_name" > db.sql
+
+#=================================================
 # END OF SCRIPT
 #=================================================
 
-ynh_script_progression --message="Backup script completed for $app. (YunoHost will then actually copy those files to the archive)." --time --last
+ynh_print_info --message="Backup script completed for $app. (YunoHost will then actually copy those files to the archive)." --time --last

--- a/scripts/backup
+++ b/scripts/backup
@@ -103,4 +103,4 @@ ynh_mysql_dump_db --database="$db_name" > db.sql
 # END OF SCRIPT
 #=================================================
 
-ynh_print_info --message="Backup script completed for $app. (YunoHost will then actually copy those files to the archive)." --time --last
+ynh_print_info --message="Backup script completed for $app. (YunoHost will then actually copy those files to the archive)."

--- a/scripts/backup
+++ b/scripts/backup
@@ -35,11 +35,6 @@ db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 #=================================================
 # STANDARD BACKUP STEPS
 #=================================================
-# STOP SYSTEMD SERVICE
-#=================================================
-ynh_script_progression --message="Stopping a systemd service..." --time --weight=1
-
-ynh_systemd_action --service_name=$app --action="stop" --log_path="/var/log/$app/$app.log"
 
 #=================================================
 # BACKUP THE APP MAIN DIR
@@ -98,13 +93,6 @@ ynh_backup --src_path="/etc/systemd/system/$app.service"
 #=================================================
 
 ynh_backup --src_path="/etc/cron.d/$app"
-
-#=================================================
-# START SYSTEMD SERVICE
-#=================================================
-ynh_script_progression --message="Starting a systemd service..." --time --weight=1
-
-ynh_systemd_action --service_name=$app --action="start" --log_path="/var/log/$app/$app.log"
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/backup
+++ b/scripts/backup
@@ -36,7 +36,7 @@ db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 # DECLARE DATA AND CONF FILES TO BACKUP
 #=================================================
 
-ynh_print_info --message="Declaring files to be backuped..."
+ynh_print_info --message="Declaring files to be backed up..."
 
 # N.B. : the following 'ynh_backup' calls are only a *declaration* of what needs
 # to be backuped and not an actual copy of any file. The actual backup that


### PR DESCRIPTION
## Problem

Some weird things happening in backup script
- `ynh_backup` only declare files to be backuped and does not perform any "real" copy whatsoever
- Hence it's overkill and misleading to have progress bars ... In fact on a real server if you launch a "backup create", you will see your N apps running the backup scripts super quick and flooding messages with progress bar as if so much stuff happened but nope ... The real stuff happens later when the archive is actually created with the files declared by `ynh_backup`
- And apart from maybe specific edge cases, there's no need to start/stop the service during backup operations ... Start/stopping the service creates a service interruption that may disrupt experience for users...
- One could think that the service should be stopped during mysql dump, but nope, the helper uses a  --single-transaction ... So unless you're doing something very specific, no need to start/stop the service

## Solution

- Tweak the backup script, have 2 steps. One about declaring files. The second one about creating database dumps. There's no point in having progress bars.

## PR Status
- [X] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.