### PR TITLE
Section name 

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -297,7 +297,7 @@ ynh_use_logrotate
 ### If you're not using these lines:
 ###		- You can remove these files in conf/.
 ###		- Remove the section "REMOVE SERVICE FROM ADMIN PANEL" in the remove script
-###		- As well as the section "ADVERTISE SERVICE IN ADMIN PANEL" in the restore script
+###		- As well as the section "INTEGRATE SERVICE IN YUNOHOST" in the restore script
 
 yunohost service add $app --description "A short description of the app" --log "/var/log/$app/$app.log"
 


### PR DESCRIPTION
## Problem
In install script, mention is made of **ADVERTISE SERVICE IN ADMIN PANEL** section to be found in the restore script that is in fact called **INTEGRATE SERVICE IN YUNOHOST** 

## Solution
- *homogenize section entries*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/REPLACEBYYOURAPP_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/REPLACEBYYOURAPP_ynh%20PR-NUM-%20(USERNAME)/)  
