### PR TITLE
improving modify a config file step during upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -147,12 +147,15 @@ ynh_add_fpm_config
 #=================================================
 
 #=================================================
-# STORE THE CONFIG FILE CHECKSUM
+# MODIFY A CONFIG FILE
 #=================================================
 
 ### Verify the checksum of a file, stored by `ynh_store_file_checksum` in the install script.
 ### And create a backup of this file if the checksum is different. So the file will be backed up if the admin had modified it.
 ynh_backup_if_checksum_is_different --file="$final_path/CONFIG_FILE"
+
+ynh_replace_string --match_string="match_string" --replace_string="replace_string" --target_file="$final_path/CONFIG_FILE"
+
 # Recalculate and store the checksum of the file for the next upgrade.
 ynh_store_file_checksum --file="$final_path/CONFIG_FILE"
 


### PR DESCRIPTION
Just trying to clarify that step during upgrade.
to let show that first, you have to `ynh_backup_if_checksum_is_different`
then you can make changes
and at the end you have to `ynh_store_file_checksum`