### PR TITLE
Add port for ynh_add_nginx_config

### DIFF
--- a/scripts/change_url
+++ b/scripts/change_url
@@ -28,6 +28,7 @@ ynh_script_progression --message="Loading installation settings..." --time --wei
 
 # Needed for helper "ynh_add_nginx_config"
 final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+port=$(ynh_app_setting_get --app=$app --key=port)
 
 # Add settings here as needed by your application
 #db_name=$(ynh_app_setting_get --app=$app --key=db_name)


### PR DESCRIPTION
## Problem
- When ` __ PORT__` is used in nginx.conf, ynh_add_nginx_config will not changed it if $port is not initialized with the port number. This will cause nginx to fail at reload.

## Solution
- *Initialize $port from the app settings. If port is not set in app settings, nothing will happen*

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

