### PR TITLE
Update systemd.service

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -9,5 +9,22 @@ Group=__APP__
 WorkingDirectory=__FINALPATH__/
 ExecStart=__FINALPATH__/script >> /var/log/__APP__/__APP__.log 2>&1
 
+# Sandboxing options to harden security
+# Depending on specificities of your service/app, you may need to tweak these 
+# .. but this should be a good baseline
+# Details for these options: https://www.freedesktop.org/software/systemd/man/systemd.exec.html
+NoNewPrivileges=yes
+PrivateTmp=yes
+PrivateDevices=yes
+DevicePolicy=closed
+ProtectSystem=full
+ProtectControlGroups=yes
+ProtectKernelModules=yes
+ProtectKernelTunables=yes
+RestrictRealtime=yes
+RestrictSUIDSGID=yes
+MemoryDenyWriteExecute=yes
+LockPersonality=yes
+
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
Follow-up of https://github.com/YunoHost/issues/issues/1515

I'm looking into some options to improve the overall security of systemd services (which turns out to in fact be also relevant for the core services as default services configuration like nginx and others ain't that great in vanilla Debian ?). We should try to care at least a bit about this considering the Yunohost's ecosystem ain't based on containerization.

Anyway ... I read quickly https://gist.github.com/ageis/f5595e59b1cddb1513d1b425a323db04 and https://www.freedesktop.org/software/systemd/man/systemd.exec.html to check what these means and tried to come up with what I think should be some sane default values for webapps. But pretty sure that some specific apps could have regression due to this ... 

Ideally we could go one step further and enable stuff like `ProtectHome` and `RestrictNamespaces` but really requires significantly more work for packagers, so we'll see later

By the way https://github.com/alegrey91/systemd-service-hardening like seems a pretty interesting tool