### PR TITLE
Fix systemd stdout/stderr

### DIFF
--- a/conf/systemd.service
+++ b/conf/systemd.service
@@ -7,7 +7,9 @@ Type=simple
 User=__APP__
 Group=__APP__
 WorkingDirectory=__FINALPATH__/
-ExecStart=__FINALPATH__/script >> /var/log/__APP__/__APP__.log 2>&1
+ExecStart=__FINALPATH__/script
+StandardOutput=append:/var/log/__APP__/__APP__.log
+StandardError=inherit
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
## Problem
- *Redirect stdout and stderr doesn't work*

## Solution
- *We can use `StandardOutput/Error` as explained [here](https://unix.stackexchange.com/a/321716) or just remove the redirection because:*
> systemd already sends the standard output and error of the service process(es) to its journal, without any such settings in the service unit. You can view it with 

## PR Status
- [ ] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*

[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/REPLACEBYYOURAPP_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/REPLACEBYYOURAPP_ynh%20PR-NUM-%20(USERNAME)/)  
