### PR TITLE
Obsolete /  superfluous ask strings for standard arguments

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -28,38 +28,22 @@
             {
                 "name": "domain",
                 "type": "domain",
-                "ask": {
-                    "en": "Choose a domain name for ynhexample",
-                    "fr": "Choisissez un nom de domaine pour ynhexample"
-                },
                 "example": "example.com"
             },
             {
                 "name": "path",
                 "type": "path",
-                "ask": {
-                    "en": "Choose a path for ynhexample",
-                    "fr": "Choisissez un chemin pour ynhexample"
-                },
                 "example": "/example",
                 "default": "/example"
             },
             {
                 "name": "admin",
                 "type": "user",
-                "ask": {
-                    "en": "Choose an admin user",
-                    "fr": "Choisissez l'administrateur"
-                },
                 "example": "johndoe"
             },
             {
                 "name": "is_public",
                 "type": "boolean",
-                "ask": {
-                    "en": "Is it a public application?",
-                    "fr": "Est-ce une application publique ?"
-                },
                 "default": true
             },
             {
@@ -75,10 +59,6 @@
             {
                 "name": "password",
                 "type": "password",
-                "ask": {
-                    "en": "Set the administrator password",
-                    "fr": "Définissez le mot de passe administrateur"
-                },
                 "help": {
                     "en": "Use the help field to add an information for the admin about this question.",
                     "fr": "Utilisez le champ aide pour ajouter une information à l'intention de l'administrateur à propos de cette question."


### PR DESCRIPTION
Sooo I don't know how to properly document this in example_ynh, but since 4.1, it's obsolete / superfluous to provide ask strings for default arguments.

[Default arguments are](https://github.com/YunoHost/yunohost/blob/807b577cf27b363bf6db6daade2d6ad836cdd08e/src/yunohost/app.py#L2120-L2128) :
- domain (type domain, name domain)
- path (type path, name path)
- admin user (type user, name admin)
- password (type password, name password)
- is_public (type boolean, name is_public)

This is because these args come over and over again in apps and it's just : 
- not i18n friendly, c.f. past experiment about translating those strings via weblate, translators had to translate a gazillion time the same string with minor variations (typically the app name)
- not packager friendly (asking yourself over and over how to formulate the question, wether or not to put the app id)
- [etc](https://github.com/YunoHost/yunohost/pull/981)

If packagers want to add specific info to these, they can through the help key ...

As said, not sure how to properly document this because json doesn't allow comments ... With just the current change, pretty sure a newcomers is gonna be confused why some strings have 'ask' strings and most don't.

