### PR TITLE
Fix "Remove various files" step

### DIFF
--- a/scripts/remove
+++ b/scripts/remove
@@ -119,10 +119,10 @@ ynh_remove_fail2ban_config
 ynh_secure_remove --file="/etc/cron.d/$app"
 
 # Remove a directory securely
-ynh_secure_remove --file="/etc/$app/"
+ynh_secure_remove --file="/etc/$app"
 
 # Remove the log files
-ynh_secure_remove --file="/var/log/$app/"
+ynh_secure_remove --file="/var/log/$app"
 
 #=================================================
 # GENERIC FINALIZATION


### PR DESCRIPTION
`ynh_secure_remove` won't remove paths that end in a slash