### PR TITLE
Switching to $app:www-data owner

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -161,8 +161,7 @@ ynh_setup_source --dest_dir="$final_path"
 # this will be treated as a security issue.
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
-chown -R root: "$final_path"
-chown root:$app "$final_path"
+chown -R $app:www-data "$final_path"
 
 #=================================================
 # NGINX CONFIGURATION

--- a/scripts/restore
+++ b/scripts/restore
@@ -76,8 +76,7 @@ ynh_restore_file --origin_path="$final_path"
 # this will be treated as a security issue.
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
-chown -R root: "$final_path"
-chown root:$app "$final_path"
+chown -R $app:www-data "$final_path"
 
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -129,8 +129,7 @@ fi
 # this will be treated as a security issue.
 chmod 750 "$final_path"
 chmod -R o-rwx "$final_path"
-chown -R root: "$final_path"
-chown root:$app "$final_path"
+chown -R $app:www-data "$final_path"
 
 #=================================================
 # NGINX CONFIGURATION


### PR DESCRIPTION
## Problem
- *From various implementation made `chown -R root: "$final_path"` was never usefull*

## Solution
- *better to do `chown -R $app:www-data "$final_path"` or `chown -R $app:$app "$final_path"`* if nginx never access directly to files

## PR Status
- [x] Code finished.
- [ ] Tested with Package_check.
- [ ] Fix or enhancement tested.
- [ ] Upgrade from last version tested.
- [ ] Can be reviewed and tested.

## Package_check results
---
* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
