### PR TITLE
Move repeated code into functions in _common.sh

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -11,6 +11,146 @@ pkg_dependencies="deb1 deb2 php$YNH_DEFAULT_PHP_VERSION-deb1 php$YNH_DEFAULT_PHP
 # PERSONAL HELPERS
 #=================================================
 
+function test_folder {
+	test ! -e "$final_path" || ynh_die --message="$final_path path already contains a directory"
+}
+
+function install_dependencies {
+	### `ynh_install_app_dependencies` allows you to add any "apt" dependencies to the package.
+	### Those deb packages will be installed as dependencies of this package.
+	### If you're not using this helper:
+	###		- Remove the section "REMOVE DEPENDENCIES" in the remove script
+	###		- Remove the variable "pkg_dependencies" in _common.sh
+	###		- As well as the section "REINSTALL DEPENDENCIES" in the restore script
+	###		- And the section "UPGRADE DEPENDENCIES" in the upgrade script
+
+	ynh_install_app_dependencies $pkg_dependencies
+}
+
+function configure_system_user {
+		ynh_system_user_create --username=$app --home_dir="$final_path"
+}
+
+function setup_source {
+	### `ynh_setup_source` is used to install an app from a zip or tar.gz file,
+	### downloaded from an upstream source, like a git repository.
+	### `ynh_setup_source` use the file conf/app.src
+
+	# Download, check integrity, uncompress and patch the source from app.src
+	ynh_setup_source --dest_dir="$final_path"
+
+	set_permissions
+}
+
+function set_permissions {
+	# FIXME: this should be managed by the core in the future
+	# Here, as a packager, you may have to tweak the ownerhsip/permissions
+	# such that the appropriate users (e.g. maybe www-data) can access
+	# files in some cases.
+	# But FOR THE LOVE OF GOD, do not allow r/x for "others" on the entire folder -
+	# this will be treated as a security issue.
+	chown -R $app:www-data "$final_path"
+	chmod -R g=u,g-w,o-rwx "$final_path"
+}
+
+function add_config {
+	### You can add specific configuration files.
+	###
+	### Typically, put your template conf file in ../conf/your_config_file
+	### The template may contain strings such as __FOO__ or __FOO_BAR__,
+	### which will automatically be replaced by the values of $foo and $foo_bar
+	###
+	### ynh_add_config will also keep track of the config file's checksum,
+	### which later during upgrade may allow to automatically backup the config file
+	### if it's found that the file was manually modified
+	###
+	### Check the documentation of `ynh_add_config` for more info.
+
+	set_config_permissions
+
+	ynh_add_config --template="some_config_file" --destination="$final_path/some_config_file"
+
+	### For more complex cases where you want to replace stuff using regexes,
+	### you shoud rely on ynh_replace_string (which is basically a wrapper for sed)
+	### When doing so, you also need to manually call ynh_store_file_checksum
+	###
+	### ynh_replace_string --match_string="match_string" --replace_string="replace_string" --target_file="$final_path/some_config_file"
+	### ynh_store_file_checksum --file="$final_path/some_config_file"
+}
+
+function set_config_permissions {
+	# FIXME: this should be handled by the core in the future
+	# You may need to use chmod 600 instead of 400,
+	# for example if the app is expected to be able to modify its own config
+	chmod 400 "$final_path/some_config_file"
+	chown $app:$app "$final_path/some_config_file"
+}
+
+function integrate_service {
+	### `yunohost service add` integrates a service in YunoHost. It then gets
+	### displayed in the admin interface and through the others `yunohost service` commands.
+	### (N.B.: this line only makes sense if the app adds a service to the system!)
+	### If you're not using these lines:
+	###		- You can remove these files in conf/.
+	###		- Remove the section "REMOVE SERVICE INTEGRATION IN YUNOHOST" in the remove script
+	###		- As well as the section "INTEGRATE SERVICE IN YUNOHOST" in the restore script
+	###		- And the section "INTEGRATE SERVICE IN YUNOHOST" in the upgrade script
+
+	yunohost service add $app --description="A short description of the app" --log="/var/log/$app/$app.log"
+
+	### Additional options starting with 3.8:
+	###
+	### --needs_exposed_ports "$port" a list of ports that needs to be publicly exposed
+	###                               which will then be checked by YunoHost's diagnosis system
+	###                               (N.B. DO NOT USE THIS is the port is only internal!!!)
+	###
+	### --test_status "some command"  a custom command to check the status of the service
+	###                               (only relevant if 'systemctl status' doesn't do a good job)
+	###
+	### --test_conf "some command"    some command similar to "nginx -t" that validates the conf of the service
+	###
+	### Re-calling 'yunohost service add' during the upgrade script is the right way
+	### to proceed if you later realize that you need to enable some flags that
+	### weren't enabled on old installs (be careful it'll override the existing
+	### service though so you should re-provide all relevant flags when doing so)
+}
+
+function start_service {
+	### `ynh_systemd_action` is used to start a systemd service for an app.
+	### Only needed if you have configure a systemd service
+	### If you're not using these lines:
+	###		- Remove the section "STOP SYSTEMD SERVICE" and "START SYSTEMD SERVICE" in the backup script
+	###		- As well as the section "START SYSTEMD SERVICE" in the restore script
+	###		- As well as the section"STOP SYSTEMD SERVICE" and "START SYSTEMD SERVICE" in the upgrade script
+	###		- And the section "STOP SYSTEMD SERVICE" and "START SYSTEMD SERVICE" in the change_url script
+
+	# Start a systemd service
+	ynh_systemd_action --service_name=$app --action="start" --log_path="/var/log/$app/$app.log"
+}
+
+function stop_service {
+	ynh_systemd_action --service_name=$app --action="stop" --log_path="/var/log/$app/$app.log"
+}
+
+function setup_fail2ban {
+	ynh_add_fail2ban_config --logpath="/var/log/nginx/${domain}-error.log" --failregex="Regex to match into the log for a failed login"
+}
+
+function load_settings {
+	app=$YNH_APP_INSTANCE_NAME
+
+	final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+	domain=$(ynh_app_setting_get --app=$app --key=domain)
+	path_url=$(ynh_app_setting_get --app=$app --key=path)
+	language=$(ynh_app_setting_get --app=$app --key=language)
+	password=$(ynh_app_setting_get --app=$app --key=password)
+	port=$(ynh_app_setting_get --app=$app --key=port)
+	db_name=$(ynh_app_setting_get --app=$app --key=db_name)
+	db_user=$db_name
+	db_pwd=$(ynh_app_setting_get --app=$app --key=mysqlpwd)
+	phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
+}
+
 #=================================================
 # EXPERIMENTAL HELPERS
 #=================================================

--- a/scripts/backup
+++ b/scripts/backup
@@ -26,12 +26,7 @@ ynh_abort_if_errors
 #=================================================
 ynh_print_info --message="Loading installation settings..."
 
-app=$YNH_APP_INSTANCE_NAME
-
-final_path=$(ynh_app_setting_get --app=$app --key=final_path)
-domain=$(ynh_app_setting_get --app=$app --key=domain)
-db_name=$(ynh_app_setting_get --app=$app --key=db_name)
-phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
+load_settings
 
 #=================================================
 # DECLARE DATA AND CONF FILES TO BACKUP

--- a/scripts/change_url
+++ b/scripts/change_url
@@ -19,20 +19,12 @@ old_path=$YNH_APP_OLD_PATH
 new_domain=$YNH_APP_NEW_DOMAIN
 new_path=$YNH_APP_NEW_PATH
 
-app=$YNH_APP_INSTANCE_NAME
-
 #=================================================
 # LOAD SETTINGS
 #=================================================
 ynh_script_progression --message="Loading installation settings..." --time --weight=1
 
-# Needed for helper "ynh_add_nginx_config"
-final_path=$(ynh_app_setting_get --app=$app --key=final_path)
-
-# Add settings here as needed by your application
-#db_name=$(ynh_app_setting_get --app=$app --key=db_name)
-#db_user=$db_name
-#db_pwd=$(ynh_app_setting_get --app=$app --key=db_pwd)
+load_settings
 
 #=================================================
 # BACKUP BEFORE CHANGE URL THEN ACTIVE TRAP
@@ -74,7 +66,7 @@ fi
 #=================================================
 ynh_script_progression --message="Stopping a systemd service..." --time --weight=1
 
-ynh_systemd_action --service_name=$app --action="stop" --log_path="/var/log/$app/$app.log"
+stop_service
 
 #=================================================
 # MODIFY URL IN NGINX CONF
@@ -118,7 +110,7 @@ fi
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --time --weight=1
 
-ynh_systemd_action --service_name=$app --action="start" --log_path="/var/log/$app/$app.log"
+start_service
 
 #=================================================
 # RELOAD NGINX

--- a/scripts/install
+++ b/scripts/install
@@ -59,7 +59,7 @@ ynh_script_progression --message="Validating installation parameters..." --time 
 ### If the app uses NGINX as web server (written in HTML/PHP in most cases), the final path should be "/var/www/$app".
 ### If the app provides an internal web server (or uses another application server such as uWSGI), the final path should be "/opt/yunohost/$app"
 final_path=/var/www/$app
-test ! -e "$final_path" || ynh_die --message="This path already contains a folder"
+test_folder
 
 # Register (book) web path
 ynh_webpath_register --app=$app --domain=$domain --path_url=$path_url
@@ -103,15 +103,7 @@ ynh_app_setting_set --app=$app --key=port --value=$port
 #=================================================
 ynh_script_progression --message="Installing dependencies..." --time --weight=1
 
-### `ynh_install_app_dependencies` allows you to add any "apt" dependencies to the package.
-### Those deb packages will be installed as dependencies of this package.
-### If you're not using this helper:
-###		- Remove the section "REMOVE DEPENDENCIES" in the remove script
-###		- Remove the variable "pkg_dependencies" in _common.sh
-###		- As well as the section "REINSTALL DEPENDENCIES" in the restore script
-###		- And the section "UPGRADE DEPENDENCIES" in the upgrade script
-
-ynh_install_app_dependencies $pkg_dependencies
+install_dependencies
 
 #=================================================
 # CREATE DEDICATED USER
@@ -119,7 +111,7 @@ ynh_install_app_dependencies $pkg_dependencies
 ynh_script_progression --message="Configuring system user..." --time --weight=1
 
 # Create a system user
-ynh_system_user_create --username=$app --home_dir="$final_path"
+configure_system_user
 
 #=================================================
 # CREATE A MYSQL DATABASE
@@ -145,23 +137,9 @@ ynh_mysql_setup_db --db_user=$db_user --db_name=$db_name
 #=================================================
 ynh_script_progression --message="Setting up source files..." --time --weight=1
 
-### `ynh_setup_source` is used to install an app from a zip or tar.gz file,
-### downloaded from an upstream source, like a git repository.
-### `ynh_setup_source` use the file conf/app.src
-
 ynh_app_setting_set --app=$app --key=final_path --value=$final_path
-# Download, check integrity, uncompress and patch the source from app.src
-ynh_setup_source --dest_dir="$final_path"
 
-# FIXME: this should be managed by the core in the future
-# Here, as a packager, you may have to tweak the ownerhsip/permissions
-# such that the appropriate users (e.g. maybe www-data) can access
-# files in some cases.
-# But FOR THE LOVE OF GOD, do not allow r/x for "others" on the entire folder -
-# this will be treated as a security issue.
-chmod 750 "$final_path"
-chmod -R o-rwx "$final_path"
-chown -R $app:www-data "$final_path"
+setup_source
 
 #=================================================
 # NGINX CONFIGURATION
@@ -203,32 +181,7 @@ ynh_add_fpm_config
 #=================================================
 ynh_script_progression --message="Adding a configuration file..." --time --weight=1
 
-### You can add specific configuration files.
-###
-### Typically, put your template conf file in ../conf/your_config_file
-### The template may contain strings such as __FOO__ or __FOO_BAR__,
-### which will automatically be replaced by the values of $foo and $foo_bar
-###
-### ynh_add_config will also keep track of the config file's checksum,
-### which later during upgrade may allow to automatically backup the config file
-### if it's found that the file was manually modified
-###
-### Check the documentation of `ynh_add_config` for more info.
-
-ynh_add_config --template="some_config_file" --destination="$final_path/some_config_file"
-
-# FIXME: this should be handled by the core in the future
-# You may need to use chmod 600 instead of 400,
-# for example if the app is expected to be able to modify its own config
-chmod 400 "$final_path/some_config_file"
-chown $app:$app "$final_path/some_config_file"
-
-### For more complex cases where you want to replace stuff using regexes,
-### you shoud rely on ynh_replace_string (which is basically a wrapper for sed)
-### When doing so, you also need to manually call ynh_store_file_checksum
-###
-### ynh_replace_string --match_string="match_string" --replace_string="replace_string" --target_file="$final_path/some_config_file"
-### ynh_store_file_checksum --file="$final_path/some_config_file"
+add_config
 
 #=================================================
 # SETUP SYSTEMD
@@ -293,48 +246,14 @@ ynh_use_logrotate
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --time --weight=1
 
-### `yunohost service add` integrates a service in YunoHost. It then gets
-### displayed in the admin interface and through the others `yunohost service` commands.
-### (N.B.: this line only makes sense if the app adds a service to the system!)
-### If you're not using these lines:
-###		- You can remove these files in conf/.
-###		- Remove the section "REMOVE SERVICE INTEGRATION IN YUNOHOST" in the remove script
-###		- As well as the section "INTEGRATE SERVICE IN YUNOHOST" in the restore script
-###		- And the section "INTEGRATE SERVICE IN YUNOHOST" in the upgrade script
-
-yunohost service add $app --description="A short description of the app" --log="/var/log/$app/$app.log"
-
-### Additional options starting with 3.8:
-###
-### --needs_exposed_ports "$port" a list of ports that needs to be publicly exposed
-###                               which will then be checked by YunoHost's diagnosis system
-###                               (N.B. DO NOT USE THIS is the port is only internal!!!)
-###
-### --test_status "some command"  a custom command to check the status of the service
-###                               (only relevant if 'systemctl status' doesn't do a good job)
-###
-### --test_conf "some command"    some command similar to "nginx -t" that validates the conf of the service
-###
-### Re-calling 'yunohost service add' during the upgrade script is the right way
-### to proceed if you later realize that you need to enable some flags that
-### weren't enabled on old installs (be careful it'll override the existing
-### service though so you should re-provide all relevant flags when doing so)
+integrate_service
 
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --time --weight=1
 
-### `ynh_systemd_action` is used to start a systemd service for an app.
-### Only needed if you have configure a systemd service
-### If you're not using these lines:
-###		- Remove the section "STOP SYSTEMD SERVICE" and "START SYSTEMD SERVICE" in the backup script
-###		- As well as the section "START SYSTEMD SERVICE" in the restore script
-###		- As well as the section"STOP SYSTEMD SERVICE" and "START SYSTEMD SERVICE" in the upgrade script
-###		- And the section "STOP SYSTEMD SERVICE" and "START SYSTEMD SERVICE" in the change_url script
-
-# Start a systemd service
-ynh_systemd_action --service_name=$app --action="start" --log_path="/var/log/$app/$app.log"
+start_service
 
 #=================================================
 # SETUP FAIL2BAN
@@ -342,7 +261,7 @@ ynh_systemd_action --service_name=$app --action="start" --log_path="/var/log/$ap
 ynh_script_progression --message="Configuring Fail2Ban..." --time --weight=1
 
 # Create a dedicated Fail2Ban config
-ynh_add_fail2ban_config --logpath="/var/log/nginx/${domain}-error.log" --failregex="Regex to match into the log for a failed login"
+setup_fail2ban
 
 #=================================================
 # SETUP SSOWAT

--- a/scripts/remove
+++ b/scripts/remove
@@ -14,13 +14,7 @@ source /usr/share/yunohost/helpers
 #=================================================
 ynh_script_progression --message="Loading installation settings..." --time --weight=1
 
-app=$YNH_APP_INSTANCE_NAME
-
-domain=$(ynh_app_setting_get --app=$app --key=domain)
-port=$(ynh_app_setting_get --app=$app --key=port)
-db_name=$(ynh_app_setting_get --app=$app --key=db_name)
-db_user=$db_name
-final_path=$(ynh_app_setting_get --app=$app --key=final_path)
+load_settings
 
 #=================================================
 # STANDARD REMOVE

--- a/scripts/restore
+++ b/scripts/restore
@@ -26,14 +26,7 @@ ynh_abort_if_errors
 #=================================================
 ynh_script_progression --message="Loading installation settings..." --time --weight=1
 
-app=$YNH_APP_INSTANCE_NAME
-
-domain=$(ynh_app_setting_get --app=$app --key=domain)
-path_url=$(ynh_app_setting_get --app=$app --key=path)
-final_path=$(ynh_app_setting_get --app=$app --key=final_path)
-db_name=$(ynh_app_setting_get --app=$app --key=db_name)
-db_user=$db_name
-phpversion=$(ynh_app_setting_get --app=$app --key=phpversion)
+load_settings
 
 #=================================================
 # CHECK IF THE APP CAN BE RESTORED
@@ -42,8 +35,8 @@ ynh_script_progression --message="Validating restoration parameters..." --time -
 
 ynh_webpath_available --domain=$domain --path_url=$path_url \
 	|| ynh_die --message="Path not available: ${domain}${path_url}"
-test ! -d $final_path \
-	|| ynh_die --message="There is already a directory: $final_path "
+
+test_folder
 
 #=================================================
 # STANDARD RESTORATION STEPS
@@ -60,7 +53,7 @@ ynh_restore_file --origin_path="/etc/nginx/conf.d/$domain.d/$app.conf"
 ynh_script_progression --message="Recreating the dedicated system user..." --time --weight=1
 
 # Create the dedicated user (if not existing)
-ynh_system_user_create --username=$app --home_dir="$final_path"
+configure_system_user
 
 #=================================================
 # RESTORE THE APP MAIN DIR
@@ -69,15 +62,7 @@ ynh_script_progression --message="Restoring the app main directory..." --time --
 
 ynh_restore_file --origin_path="$final_path"
 
-# FIXME: this should be managed by the core in the future
-# Here, as a packager, you may have to tweak the ownerhsip/permissions
-# such that the appropriate users (e.g. maybe www-data) can access
-# files in some cases.
-# But FOR THE LOVE OF GOD, do not allow r/x for "others" on the entire folder -
-# this will be treated as a security issue.
-chmod 750 "$final_path"
-chmod -R o-rwx "$final_path"
-chown -R $app:www-data "$final_path"
+set_permissions
 
 #=================================================
 # RESTORE THE PHP-FPM CONFIGURATION
@@ -103,7 +88,7 @@ ynh_systemd_action --action=restart --service_name=fail2ban
 ynh_script_progression --message="Reinstalling dependencies..." --time --weight=1
 
 # Define and install dependencies
-ynh_install_app_dependencies $pkg_dependencies
+install_dependencies
 
 #=================================================
 # RESTORE THE MYSQL DATABASE
@@ -136,14 +121,14 @@ systemctl enable $app.service --quiet
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --time --weight=1
 
-yunohost service add $app --description="A short description of the app" --log="/var/log/$app/$app.log"
+integrate_service
 
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --time --weight=1
 
-ynh_systemd_action --service_name=$app --action="start" --log_path="/var/log/$app/$app.log"
+start_service
 
 #=================================================
 # RESTORE THE LOGROTATE CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -14,14 +14,7 @@ source /usr/share/yunohost/helpers
 #=================================================
 ynh_script_progression --message="Loading installation settings..." --time --weight=1
 
-app=$YNH_APP_INSTANCE_NAME
-
-domain=$(ynh_app_setting_get --app=$app --key=domain)
-path_url=$(ynh_app_setting_get --app=$app --key=path)
-admin=$(ynh_app_setting_get --app=$app --key=admin)
-final_path=$(ynh_app_setting_get --app=$app --key=final_path)
-language=$(ynh_app_setting_get --app=$app --key=language)
-db_name=$(ynh_app_setting_get --app=$app --key=db_name)
+load_settings
 
 #=================================================
 # CHECK VERSION
@@ -56,7 +49,7 @@ ynh_abort_if_errors
 #=================================================
 ynh_script_progression --message="Stopping a systemd service..." --time --weight=1
 
-ynh_systemd_action --service_name=$app --action="stop" --log_path="/var/log/$app/$app.log"
+stop_service
 
 #=================================================
 # ENSURE DOWNWARD COMPATIBILITY
@@ -107,7 +100,14 @@ fi
 ynh_script_progression --message="Making sure dedicated system user exists..." --time --weight=1
 
 # Create a dedicated user (if not existing)
-ynh_system_user_create --username=$app --home_dir="$final_path"
+configure_system_user
+
+#=================================================
+# UPGRADE DEPENDENCIES
+#=================================================
+ynh_script_progression --message="Upgrading dependencies..." --time --weight=1
+
+install_dependencies
 
 #=================================================
 # DOWNLOAD, CHECK AND UNPACK SOURCE
@@ -117,19 +117,8 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..." --time --weight=1
 
-	# Download, check integrity, uncompress and patch the source from app.src
-	ynh_setup_source --dest_dir="$final_path"
+	setup_source
 fi
-
-# FIXME: this should be managed by the core in the future
-# Here, as a packager, you may have to tweak the ownerhsip/permissions
-# such that the appropriate users (e.g. maybe www-data) can access
-# files in some cases.
-# But FOR THE LOVE OF GOD, do not allow r/x for "others" on the entire folder -
-# this will be treated as a security issue.
-chmod 750 "$final_path"
-chmod -R o-rwx "$final_path"
-chown -R $app:www-data "$final_path"
 
 #=================================================
 # NGINX CONFIGURATION
@@ -138,13 +127,6 @@ ynh_script_progression --message="Upgrading NGINX web server configuration..." -
 
 # Create a dedicated NGINX config
 ynh_add_nginx_config
-
-#=================================================
-# UPGRADE DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Upgrading dependencies..." --time --weight=1
-
-ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================
 # PHP-FPM CONFIGURATION
@@ -165,25 +147,7 @@ ynh_add_fpm_config
 #=================================================
 ynh_script_progression --message="Updating a configuration file..." --time --weight=1
 
-### Same as during install
-###
-### The file will automatically be backed-up if it's found to be manually modified (because
-### ynh_add_config keeps track of the file's checksum)
-
-ynh_add_config --template="some_config_file" --destination="$final_path/some_config_file"
-
-# FIXME: this should be handled by the core in the future
-# You may need to use chmod 600 instead of 400,
-# for example if the app is expected to be able to modify its own config
-chmod 400 "$final_path/some_config_file"
-chown $app:$app "$final_path/some_config_file"
-
-### For more complex cases where you want to replace stuff using regexes,
-### you shoud rely on ynh_replace_string (which is basically a wrapper for sed)
-### When doing so, you also need to manually call ynh_store_file_checksum
-###
-### ynh_replace_string --match_string="match_string" --replace_string="replace_string" --target_file="$final_path/some_config_file"
-### ynh_store_file_checksum --file="$final_path/some_config_file"
+add_config
 
 #=================================================
 # SETUP SYSTEMD
@@ -208,14 +172,14 @@ ynh_use_logrotate --non-append
 #=================================================
 ynh_script_progression --message="Integrating service in YunoHost..." --time --weight=1
 
-yunohost service add $app --description="A short description of the app" --log="/var/log/$app/$app.log"
+integrate_service
 
 #=================================================
 # START SYSTEMD SERVICE
 #=================================================
 ynh_script_progression --message="Starting a systemd service..." --time --weight=1
 
-ynh_systemd_action --service_name=$app --action="start" --log_path="/var/log/$app/$app.log"
+start_service
 
 #=================================================
 # UPGRADE FAIL2BAN
@@ -223,7 +187,7 @@ ynh_systemd_action --service_name=$app --action="start" --log_path="/var/log/$ap
 ynh_script_progression --message="Reconfiguring Fail2Ban..." --time --weight=1
 
 # Create a dedicated Fail2Ban config
-ynh_add_fail2ban_config --logpath="/var/log/nginx/${domain}-error.log" --failregex="Regex to match into the log for a failed login"
+setup_fail2ban
 
 #=================================================
 # RELOAD NGINX


### PR DESCRIPTION
## Problem

Most of the scripts contain lots of duplicate code that is shared with other scripts. Maintaining multiple copies of the same code is unnecessarily time-consuming and error-prone.

## Solution

This PR moves repeated code blocks into bash functions in `_common.sh`, ensuring that there is only one copy that needs to be modified/updated.

## PR Status

- [x] Code finished and ready to be reviewed/tested