### PR TITLE
ynh_webpath_available is useless

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -41,8 +41,6 @@ datadir=$(ynh_app_setting_get --app=$app --key=datadir)
 #=================================================
 ynh_script_progression --message="Validating restoration parameters..." --time --weight=1
 
-ynh_webpath_available --domain=$domain --path_url=$path_url \
-	|| ynh_die --message="Path not available: ${domain}${path_url}"
 test ! -d $final_path \
 	|| ynh_die --message="There is already a directory: $final_path "
 


### PR DESCRIPTION
## Problem

Calling 'ynh_webpath_available' is quite probably pointless: 
- in the install script, just call ynh_webpath_register,
- in the restore script, there's no need to check/register the webpath (it's implicitly already booked before starting the restore script)
- (Also the helper always return exit code 0, so 'ynh_webpath_available || ynh_die' is useless :/)
- The only kind of actual use-case for this helper is, for example, is if you'd like to book some `/.well-known` uri, but first want to check if it's already booked by something else to not trigger an error while trying to book it ...

## Solution

- Just don't use ynh_webpath_available
