### PR TITLE
Update licence documentation url

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
 File containing the license of your package.
 
 More information here:
-https://github.com/YunoHost/doc/blob/master/pages/04.contribute/04.packaging_apps/15.quality_tests/02.yep/packaging_apps_guidelines.fr.md#yep-13
+https://yunohost.org/packaging_apps_guidelines#yep-1-3


### PR DESCRIPTION
## Problem

- Url of documentation about licenses returns 404

## Solution

- Update the url

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
