### PR TITLE
Update upgrade

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -102,6 +102,13 @@ if ! ynh_permission_exists --permission="api"; then
 fi
 
 #=================================================
+# UPGRADE DEPENDENCIES
+#=================================================
+ynh_script_progression --message="Upgrading dependencies..." --time --weight=1
+
+ynh_install_app_dependencies $pkg_dependencies
+
+#=================================================
 # CREATE DEDICATED USER
 #=================================================
 ynh_script_progression --message="Making sure dedicated system user exists..." --time --weight=1
@@ -138,13 +145,6 @@ ynh_script_progression --message="Upgrading NGINX web server configuration..." -
 
 # Create a dedicated NGINX config
 ynh_add_nginx_config
-
-#=================================================
-# UPGRADE DEPENDENCIES
-#=================================================
-ynh_script_progression --message="Upgrading dependencies..." --time --weight=1
-
-ynh_install_app_dependencies $pkg_dependencies
 
 #=================================================
 # PHP-FPM CONFIGURATION


### PR DESCRIPTION
Following Alex fix for Matomo: https://github.com/YunoHost-Apps/matomo_ynh/pull/69/commits/aa41db0fd0b7127617d30fdce5e7811079ab18d0

When we change PHP version PHP7.3 -> PHP8.0. We need to download the dependencies before updating the app.