### PR TITLE
document php version choice with "YNH_PHP_VERSION"

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -5,17 +5,20 @@
 #=================================================
 # PHP APP SPECIFIC
 #=================================================
-# PHP version used by the application can be changed here
-# YunoHost uses a "default php" version depending of its version
-## YunoHost version "11.X" => php 7.4
-## YunoHost version "4.X"  => php 7.3
+# Depending on its version, YunoHost uses different default PHP version:
+## YunoHost version "11.X" => PHP 7.4
+## YunoHost version "4.X"  => PHP 7.3
 #
-# This behaviour can be overrided by setting the variable
+# This behaviour can be overridden by setting the YNH_PHP_VERSION variable
 #YNH_PHP_VERSION=7.3
 #YNH_PHP_VERSION=7.4
 #YNH_PHP_VERSION=8.0
-# For more information, see the "php helper": https://github.com/YunoHost/yunohost/blob/dev/helpers/php#L3-L6=
-# Or this php package: https://github.com/YunoHost-Apps/grav_ynh/blob/master/scripts/_common.sh
+# For more information, see the PHP application helper: https://github.com/YunoHost/yunohost/blob/dev/helpers/php#L3-L6
+# Or this app package depending on PHP: https://github.com/YunoHost-Apps/grav_ynh/blob/master/scripts/_common.sh
+# PHP dependencies used by the app (must be on a single line)
+#php_dependencies="php$YNH_PHP_VERSION-deb1 php$YNH_PHP_VERSION-deb2"
+# or, if you do not need a custom YNH_PHP_VERSION:
+php_dependencies="php$YNH_DEFAULT_PHP_VERSION-deb1 php$YNH_DEFAULT_PHP_VERSION-deb2"
 
 # dependencies used by the app (must be on a single line)
 pkg_dependencies="deb1 deb2 php$YNH_PHP_VERSION-deb1 php$YNH_PHP_VERSION-deb2"

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -21,7 +21,7 @@
 php_dependencies="php$YNH_DEFAULT_PHP_VERSION-deb1 php$YNH_DEFAULT_PHP_VERSION-deb2"
 
 # dependencies used by the app (must be on a single line)
-pkg_dependencies="deb1 deb2 php$YNH_PHP_VERSION-deb1 php$YNH_PHP_VERSION-deb2"
+pkg_dependencies="deb1 deb2 $php_dependencies"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -3,9 +3,22 @@
 #=================================================
 # COMMON VARIABLES
 #=================================================
+# PHP APP SPECIFIC
+#=================================================
+# PHP version used by the application can be changed here
+# YunoHost uses a "default php" version depending of its version
+## YunoHost version "11.X" => php 7.4
+## YunoHost version "4.X"  => php 7.3
+#
+# This behaviour can be overrided by setting the variable
+#YNH_PHP_VERSION=7.3
+#YNH_PHP_VERSION=7.4
+#YNH_PHP_VERSION=8.0
+# For more information, see the "php helper": https://github.com/YunoHost/yunohost/blob/dev/helpers/php#L3-L6=
+# Or this php package: https://github.com/YunoHost-Apps/grav_ynh/blob/master/scripts/_common.sh
 
-# dependencies used by the app
-pkg_dependencies="deb1 deb2 php$YNH_DEFAULT_PHP_VERSION-deb1 php$YNH_DEFAULT_PHP_VERSION-deb2"
+# dependencies used by the app (must be on a single line)
+pkg_dependencies="deb1 deb2 php$YNH_PHP_VERSION-deb1 php$YNH_PHP_VERSION-deb2"
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
## Problem

- It was hard to me to find how to change the php version used in Debian 11

## Solution

- Document "YNH_PHP_VERSION" in the example package

Feel free to edit/comment/merge this proposal

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable) 

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
