### PR TITLE
Create application log directory in restore

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -155,6 +155,7 @@ systemctl enable $app.service --quiet
 ynh_script_progression --message="Restoring the logrotate configuration..." --weight=1
 
 ynh_restore_file --origin_path="/etc/logrotate.d/$app"
+mkdir --parents /var/log/$app
 
 #=================================================
 # INTEGRATE SERVICE IN YUNOHOST


### PR DESCRIPTION
## Problem
When restoring an application based on this example, you have to re-create the /var/log application directory in case it has been deleted.
This happens if the application have been backup, removed and then restored. 

## Solution

Added a mkdir in the restore script

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests
Not needed as it's just an example script