### PR TITLE
Fixing dead link in LICENSE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
 File containing the license of your package.
 
 More information here:
-https://yunohost.org/packaging_apps_guidelines#yep-1-3
+https://choosealicense.com/


### PR DESCRIPTION
## Problem

There is a dead link to the ynh doc in the LICENSE.

## Solution

As I didn't find anything in the ynh docs related to the choice of the license, I put the link to this good resource : https://choosealicense.com/ 
If you believe that something else should be here instead, please add a comment.

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
