### PR TITLE
Color syntax in example files and explain yes/no overrides for config panel.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+tests.toml.example diff=toml
+config_panel.toml.example diff=toml

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-tests.toml.example diff=toml
-config_panel.toml.example diff=toml
+tests.toml.example linguist-language=toml
+config_panel.toml.example linguist-language=toml

--- a/config_panel.toml.example
+++ b/config_panel.toml.example
@@ -222,6 +222,13 @@ services = ["__APP__"]
         ## (optional) set to true in order to redact the value in operation logs
         # redact = false
 
+        ## (optional) for boolean questions you can specify replacement values 
+        ## bound to true and false, in case property is bound to config file
+        # useful if bound property in config file expects something else than integer 1
+        yes = "Enable" 
+        # useful if bound property in config file expects something else than integer 0
+        no = "Disable" 
+
         ## (optional) A validation pattern
         ## ---------------------------------------------------------------------
         ## IMPORTANT: your pattern should be between simple quote, not double.


### PR DESCRIPTION
## Problem

- `*.toml.example` files didn't have syntax highlighting.
- possibility to override value for `true`/`false` values in `boolean` questions was not explained.

## Solution

- added `.gitattributes` as per [documentation](https://github.com/github/linguist/blob/master/docs/overrides.md) and [languages list](https://github.com/github/linguist/blob/master/lib/linguist/languages.yml).
- explained to best of my understanding inner workings of [BooleanQuestion](https://github.com/YunoHost/yunohost/blob/dev/src/utils/form.py#L543)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
