### PR TITLE
Fix outdated mentions to app.src

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -39,9 +39,9 @@ ynh_script_progression --message="Setting up source files..." --weight=1
 
 ### `ynh_setup_source` is used to install an app from a zip or tar.gz file,
 ### downloaded from an upstream source, like a git repository.
-### `ynh_setup_source` use the file conf/app.src
+### `ynh_setup_source` use the file manifest.toml
 
-# Download, check integrity, uncompress and patch the source from app.src
+# Download, check integrity, uncompress and patch the source from manifest.toml
 ynh_setup_source --dest_dir="$install_dir"
 
 # $install_dir will automatically be initialized with some decent 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -72,7 +72,7 @@ if [ "$upgrade_type" == "UPGRADE_APP" ]
 then
 	ynh_script_progression --message="Upgrading source files..." --weight=1
 
-	# Download, check integrity, uncompress and patch the source from app.src
+	# Download, check integrity, uncompress and patch the source from manifest.toml
 	ynh_setup_source --dest_dir="$install_dir"
 fi
 


### PR DESCRIPTION
## Problem

- Outdated mentions of `app.src` (file from manifest v1) where still present in the comments.

## Solution

- Replace `app.src` by the new file containing source information in manifest v2 (`manifest.toml`) 

## PR Status

- [X] Code finished and ready to be reviewed/tested
- [X] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
