### PR TITLE
Create log files at install and restore steps

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -26,7 +26,7 @@ source /usr/share/yunohost/helpers
 # ...
 
 #
-# $app is the app id (i.e. 'example' for first install, 
+# $app is the app id (i.e. 'example' for first install,
 # or 'example__2', '__3', ... for multi-instance installs)
 #
 
@@ -44,7 +44,7 @@ ynh_script_progression --message="Setting up source files..." --weight=1
 # Download, check integrity, uncompress and patch the source from manifest.toml
 ynh_setup_source --dest_dir="$install_dir"
 
-# $install_dir will automatically be initialized with some decent 
+# $install_dir will automatically be initialized with some decent
 # permission by default ... however, you may need to recursively reapply
 # ownership to all files such as after the ynh_setup_source step
 chown -R $app:www-data "$install_dir"
@@ -95,6 +95,12 @@ ynh_add_systemd_config
 ###		- And the section "INTEGRATE SERVICE IN YUNOHOST" in the upgrade script
 
 yunohost service add $app --description="A short description of the app" --log="/var/log/$app/$app.log"
+
+# Create the log file (required for fail2ban)
+mkdir -p "/var/log/$app"
+touch "/var/log/$app/$app.log"
+chown -R "$app:$app" "/var/log/$app"
+chmod -R u=rwX,g=rX,o= "/var/log/$app"
 
 ### Additional options starting with 3.8:
 ###

--- a/scripts/restore
+++ b/scripts/restore
@@ -17,7 +17,7 @@ ynh_script_progression --message="Restoring the app main directory..." --weight=
 
 ynh_restore_file --origin_path="$install_dir"
 
-# $install_dir will automatically be initialized with some decent 
+# $install_dir will automatically be initialized with some decent
 # permissions by default ... however, you may need to recursively reapply
 # ownership to all files such as after the ynh_setup_source step
 chown -R $app:www-data "$install_dir"
@@ -56,6 +56,12 @@ ynh_restore_file --origin_path="/etc/systemd/system/$app.service"
 systemctl enable $app.service --quiet
 
 yunohost service add $app --description="A short description of the app" --log="/var/log/$app/$app.log"
+
+# Create the log file (required for fail2ban)
+mkdir -p "/var/log/$app"
+touch "/var/log/$app/$app.log"
+chown -R "$app:$app" "/var/log/$app"
+chmod -R u=rwX,g=rX,o= "/var/log/$app"
 
 ynh_restore_file --origin_path="/etc/logrotate.d/$app"
 


### PR DESCRIPTION
## Problem

fail2ban fails if the log file does not exist yet

## Solution

Create the file at install and restore steps.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
