### PR TITLE
Make app url clickable in doc/POST_INSTALL.md

### DIFF
--- a/doc/POST_INSTALL.md
+++ b/doc/POST_INSTALL.md
@@ -1,6 +1,6 @@
 This is a dummy disclaimer to display after the install
 
-The app url is `__DOMAIN____PATH__`
+The app url is <https://__DOMAIN____PATH__>
 
 The app install dir is `__INSTALL_DIR__`
 


### PR DESCRIPTION
## Problem

- the "app url" showed by doc/POST_INSTALL.md is not a link

## Solution

- make it a clickable link

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
