### PR TITLE
add comment reffering to https://spdx.org/licenses/

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -13,7 +13,7 @@ maintainers = ["johndoe"]
 
 [upstream]
 # NB: Only the "license" key is mandatory. Remove entries for which there's no relevant data
-license = "free"
+license = "free" # you can see the available licenses identifiers list here: https://spdx.org/licenses/
 website = "https://example.com"
 demo = "https://demo.example.com"
 admindoc = "https://yunohost.org/packaging_apps"


### PR DESCRIPTION
## Problem

- it can be confusing what to fill for the licence without the linter warning

## Solution

- add comment reffering to https://spdx.org/licenses/

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
