### PR TITLE
Update link to autoupdate_app_sources.py in manifest comment

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -100,7 +100,7 @@ ram.runtime = "50M"
     url = "https://github.com/foo/bar/archive/refs/tags/v1.2.3.tar.gz"
     sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
 
-    # These infos are used by https://github.com/YunoHost/apps/blob/master/tools/autoupdate_app_sources/autoupdate_app_sources.py
+    # These infos are used by https://github.com/YunoHost/apps_tools/blob/main/autoupdate_app_sources/autoupdate_app_sources.py
     # to auto-update the previous asset urls and sha256sum + manifest version
     # assuming the upstream's code repo is on github and relies on tags or releases
     # See the 'sources' resource documentation for more details


### PR DESCRIPTION
## Problem

- There exists a deadlink in comment that documents how to set autoupdate strategy

## Solution

- Fix the link to the source to its new location

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
