### PR TITLE
Use .gitattributes to mark READMEs as autogenerated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 tests.toml.example linguist-language=toml
 config_panel.toml.example linguist-language=toml
+*README*.md linguist-generated=true
+manifest.toml linguist-language=toml

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,3 @@
 tests.toml.example linguist-language=toml
 config_panel.toml.example linguist-language=toml
 *README*.md linguist-generated=true
-manifest.toml linguist-language=toml


### PR DESCRIPTION
Based on the work of orhtej2 here: https://github.com/YunoHost/apps_tools/pull/19

I’m adding it to the example app so newly packaged apps could already profit from it