### PR TITLE
Set file group permission to www-data

### DIFF
--- a/scripts/install
+++ b/scripts/install
@@ -78,7 +78,7 @@ ynh_config_add --template="some_config_file" --destination="$install_dir/some_co
 ### You may need to use chmod 600 instead of 400,
 ### for example if the app is expected to be able to modify its own config
 chmod 400 "$install_dir/some_config_file"
-chown "$app:$app" "$install_dir/some_config_file"
+chown "$app:www-data" "$install_dir/some_config_file"
 
 ### For more complex cases where you want to replace stuff using regexes,
 ### you shoud rely on ynh_replace (which is basically a wrapper for sed)

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -79,7 +79,7 @@ ynh_config_add --template="some_config_file" --destination="$install_dir/some_co
 ### You may need to use chmod 600 instead of 400,
 ### for example if the app is expected to be able to modify its own config
 chmod 400 "$install_dir/some_config_file"
-chown "$app:$app" "$install_dir/some_config_file"
+chown "$app:www-data" "$install_dir/some_config_file"
 
 ### For more complex cases where you want to replace stuff using regexes,
 ### you shoud rely on ynh_replace (which is basically a wrapper for sed)


### PR DESCRIPTION
I find confusing that current recommendation for file permissions to `$app:$app` when everything else in the script is chowned to `$app:www-data` by default. 
Although I may miss a specific reason for it?

Also @alexAubin for an app you had recommended me to rather use `www-data` as in this PR. 