### PR TITLE
[fix] Datadir should not be available from www-data by default

### DIFF
--- a/scripts/restore
+++ b/scripts/restore
@@ -28,7 +28,7 @@ ynh_script_progression "Restoring the data directory..."
 ynh_restore "$data_dir"
 
 ### (Same as for install dir)
-chown -R "$app:www-data" "$data_dir"
+chown -R "$app:$app" "$data_dir"
 
 #=================================================
 # RESTORE THE MYSQL DATABASE


### PR DESCRIPTION
## Problem

I think data dir should not be avialble to www-data user cause the apps generally manage the access to their data.

## Solution

Change default suggested ownership

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
