### PR TITLE
Add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,19 @@
+# EditorConfig: https://editorconfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+spelling_language = en-US
+# Let's also remove trailing whitespaces, even in markdown:
+# https://www.markdownguide.org/basic-syntax/#line-breaks
+trim_trailing_whitespace = true
+
+[**_fr.md]
+spelling_language = fr
+

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ It shall NOT be edited by hand.
 
 # Example app for YunoHost
 
-[![Integration level](https://dash.yunohost.org/integration/example.svg)](https://dash.yunohost.org/appci/app/example) ![Working status](https://ci-apps.yunohost.org/ci/badges/example.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/example.maintain.svg)  
+[![Integration level](https://dash.yunohost.org/integration/example.svg)](https://dash.yunohost.org/appci/app/example) ![Working status](https://ci-apps.yunohost.org/ci/badges/example.status.svg) ![Maintenance status](https://ci-apps.yunohost.org/ci/badges/example.maintain.svg)<br>
 [![Install Example app with YunoHost](https://install-app.yunohost.org/install-with-yunohost.svg)](https://install-app.yunohost.org/?app=example)
 
 *[Lire ce readme en français.](./README_fr.md)*


### PR DESCRIPTION
## Problem

I have used this template and found that I don't comply to a uniform code style 😬 (see the indentation of the two functions `validate__iface` and `set__iface`):
https://github.com/YunoHost-Apps/cryptroot-unlock_ynh/blob/bd7a7387e6ca4db620ed8c09e0c5a93e8ec93cc4/scripts/config#L35-L49

## Solution

EditorConfig is a widely supported specification to help maintain consistent coding styles:
https://editorconfig.org/#overview

Many editors support this spec natively (NeoVim, Vim, Emacs, VisualStudio Code, WebStorm, ...): https://editorconfig.org/#pre-installed

It is meant to help the developer follow a unique code style (4-spaces indentation, remove trailing spaces, ...)

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
