### PR TITLE
Document optional sources flags (esp. `in_subdir`)

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -99,6 +99,11 @@ ram.runtime = "50M"
     # You can also define other assets than "main" and add --source_id="foobar" in the previous command
     url = "https://github.com/foo/bar/archive/refs/tags/v1.2.3.tar.gz"
     sha256 = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+    # Format usually doesn't need to be set explicitly as it's automatically guessed from the extension of the URL
+    # format = "tar.gz"
+    # Is set to true by default, indicating that there's an intermediate subdir in the archive before accessing the actual files
+    # Explicitly needs to be set to false if the sources are directly in the archive root
+    # in_subdir = false
 
     # These infos are used by https://github.com/YunoHost/apps_tools/blob/main/autoupdate_app_sources/autoupdate_app_sources.py
     # to auto-update the previous asset urls and sha256sum + manifest version


### PR DESCRIPTION
## Problem

From comments for sources in `manifest.toml` it's not clear that `in_subdir` is set to true by default. A comment about that could have saved some good amount of troubleshooting (like in https://github.com/YunoHost-Apps/fossbilling_ynh/pull/2) . 

## Solution

Add respective comments.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
